### PR TITLE
Create CODE_OF_CONDUCT.md

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,57 @@
+# Code of Conduct
+
+## Our Commitment
+
+As a social change organisation, we believe in a world that is resilient, rebalanced and regenerative, where everyone can fulfil their potential.
+
+To achieve our ambitions, we know we must nurture a culture of inclusion in all of our work - within our projects, with our Fellows, partners and communities and in our building of heritage.
+
+We commit to celebrating, inspiring and making way for diverse changemakers.
+This means we have a responsibility to challenge systemic inequity and all forms of discrimination:
+- We will not accept unfair discrimination or less favourable treatment on the grounds of sex, gender, sexual orientation, race, religion or belief, disability, socio-economic background or status, age, marriage and civil partnership or pregnancy and maternity.
+- We commit to treating others with honesty, dignity and respect and refusing to engage in or support any form of harassment, bullying or unfair discrimination.
+
+## Our Community Guidelines
+
+- We bring awareness of our own power and privilege to our online community, ensuring we make space for others and take space accordingly.
+- We show respect to others by respectfully and constructively challenging ideas. We assume best intentions and communicate with kindness online, as we would offline.
+- We understand this platform doesn’t exist to directly promote individuals’ own for profit services or to provide free advertising, either commercial or political. We are strongly non-partisan and work across political divides – we're open to great conversations and discussions but we leave party politics at the door.
+
+Examples of behaviour that contributes to a positive environment for our community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologising to those affected by our mistakes, and learning from the experience
+* Focussing on what is best not just for us as individuals, but for the overall community
+  
+Examples of unacceptable behaviour include:
+
+* The use of sexualised language or imagery, and sexual attention or advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of acceptable behaviour and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces that are part of the RSA's GitHub Organisation.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behaviour may be reported to the community leaders responsible for enforcement at research@rsa.org.uk.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html and the [RSA's Diversity, Equity and Inclusion statement](https://www.thersa.org/about/diversity-equity-inclusion).
+
+The Community Guidelines are adapted from the Community Guidelines created for Circle, the RSA's online platform that connects our unique global network of Fellows.


### PR DESCRIPTION
It's generally good practice to include a code of conduct in repositories. This is a bit of a Frankenstein monster, made up of the Contributor Covenant, the Circle Community Guidelines, and the RSA EDI committment on the website.

To check
- [x] does this reflect what we want?
- [ ] who needs to approve it?
- [ ] who would receive reports of a CoC violation?
- [ ] how specific do we need to be about how the CoC will be enforced? The Contributor Covenant already suggests a process but I removed it as I doubt that a boilerplate process would work. I could try to adapt the [process explained for Circle](https://royalsocietyarts.sharepoint.com/:w:/r/RSABulletin/_layouts/15/Doc.aspx?sourcedoc=%7B5359C67F-256C-4E08-ABF9-C1AC95BA8B1D%7D&file=Circle%20Moderation.docx&action=default&mobileredirect=true)?